### PR TITLE
fix: use consistent ellipsis character in messages

### DIFF
--- a/internal/k8s/informer_repository.go
+++ b/internal/k8s/informer_repository.go
@@ -105,7 +105,7 @@ func NewInformerRepositoryWithProgress(kubeconfig, contextName string, progress 
 	if progress != nil {
 		progress <- ContextLoadProgress{
 			Context: contextName,
-			Message: "Connecting to API server...",
+			Message: "Connecting to API server…",
 			Phase:   PhaseConnecting,
 		}
 	}
@@ -237,7 +237,7 @@ func NewInformerRepositoryWithProgress(kubeconfig, contextName string, progress 
 	if progress != nil {
 		progress <- ContextLoadProgress{
 			Context: contextName,
-			Message: "Syncing core resources...",
+			Message: "Syncing core resources…",
 			Phase:   PhaseSyncingCore,
 		}
 	}
@@ -259,7 +259,7 @@ func NewInformerRepositoryWithProgress(kubeconfig, contextName string, progress 
 	if progress != nil {
 		progress <- ContextLoadProgress{
 			Context: contextName,
-			Message: "Syncing dynamic resources...",
+			Message: "Syncing dynamic resources…",
 			Phase:   PhaseSyncingDynamic,
 		}
 	}

--- a/internal/k8s/repository_pool.go
+++ b/internal/k8s/repository_pool.go
@@ -114,7 +114,7 @@ func (p *RepositoryPool) LoadContext(contextName string, progress chan<- Context
 	if progress != nil {
 		progress <- ContextLoadProgress{
 			Context: contextName,
-			Message: "Connecting to API server...",
+			Message: "Connecting to API server…",
 		}
 	}
 

--- a/internal/k8s/resource_formatters.go
+++ b/internal/k8s/resource_formatters.go
@@ -202,7 +202,7 @@ func (r *InformerRepository) formatEvents(events []corev1.Event) string {
 
 		// Truncate message if too long
 		if len(message) > 80 {
-			message = message[:77] + "..."
+			message = message[:77] + "…"
 		}
 
 		buf.WriteString(fmt.Sprintf("  %-7s %-9s %-22s %s\n", eventType, reason, age, message))

--- a/internal/messages/helpers.go
+++ b/internal/messages/helpers.go
@@ -42,7 +42,7 @@ func SuccessCmd(format string, args ...any) tea.Cmd {
 //
 // Example:
 //
-//	return messages.InfoCmd("Refreshing resource list...")
+//	return messages.InfoCmd("Refreshing resource list…")
 func InfoCmd(format string, args ...any) tea.Cmd {
 	msg := fmt.Sprintf(format, args...)
 	return func() tea.Msg {
@@ -65,4 +65,3 @@ func WrapError(err error, format string, args ...any) error {
 	context := fmt.Sprintf(format, args...)
 	return fmt.Errorf("%s: %w", context, err)
 }
-

--- a/internal/screens/config.go
+++ b/internal/screens/config.go
@@ -90,7 +90,7 @@ type ConfigScreen struct {
 
 	// Column visibility tracking (Phase 2: responsive display)
 	visibleColumns []ColumnConfig // Columns currently visible
-	hiddenCount    int             // Number of hidden columns
+	hiddenCount    int            // Number of hidden columns
 
 	// Track initialization for loading messages and periodic refresh
 	initialized bool
@@ -210,7 +210,7 @@ func (s *ConfigScreen) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Show loading message and start refresh
 		return s, tea.Batch(
 			func() tea.Msg {
-				return types.LoadingMsg("Loading " + s.config.Title + "...")
+				return types.LoadingMsg("Loading " + s.config.Title + "…")
 			},
 			s.Refresh(),
 		)
@@ -474,7 +474,7 @@ func (s *ConfigScreen) Refresh() tea.Cmd {
 			// Informers not synced yet - show loading message
 			// Periodic refresh will retry automatically
 			logging.Debug("Still loading", "screen", s.config.Title)
-			return types.LoadingMsg(fmt.Sprintf("Loading %s...", s.config.Title))
+			return types.LoadingMsg(fmt.Sprintf("Loading %s…", s.config.Title))
 		}
 
 		var items []interface{}

--- a/internal/screens/dynamic_screen.go
+++ b/internal/screens/dynamic_screen.go
@@ -68,7 +68,7 @@ func (s *DynamicScreen) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Show loading message and start sync
 		return s, tea.Batch(
 			func() tea.Msg {
-				return types.InfoMsg("Loading " + s.config.Title + "...")
+				return types.InfoMsg("Loading " + s.config.Title + "…")
 			},
 			s.Refresh(),
 		)
@@ -146,7 +146,7 @@ func (s *DynamicScreen) Refresh() tea.Cmd {
 			}
 
 			// Still syncing - show loading message (periodic refresh will retry)
-			return types.LoadingMsg("Loading " + s.config.Title + "...")
+			return types.LoadingMsg("Loading " + s.config.Title + "…")
 		}
 
 		// Informer ready - fetch data


### PR DESCRIPTION
## Summary
- Update all loading/progress messages to use proper ellipsis (…) instead of three dots (...)
- Ensures visual consistency with Claude Code message styling from PR #25

## Changes
- K8s progress messages: "Connecting to API server…"
- Screen loading messages: "Loading {resource}…"  
- Event message truncation: suffix with "…"
- Fixed whitespace alignment in config.go
- Removed trailing newline in helpers.go

## Test plan
- [x] Build succeeds: `make build`
- [x] All tests pass: `make test`
- [x] Manual testing: verified ellipsis characters display correctly in terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)